### PR TITLE
Add related resource support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,10 +1,36 @@
 AttachedDisk:
+  RelatedResources:
+    disk: initializeParams
+  Mapping:
+    name: diskName
+    sourceImageId: sourceImage
+    kmsKeySelfLink: kmsKeyName
+    sourceSnapshotId: sourceSnapshot
+    size: diskSizeGb
+    replicaZones: zone
+  ExactMapping:
+    diskEncryptionKey.rawKey: initializeParams.diskEncryptionKey.rawKey
+    diskEncryptionKey.rsaEncryptedKey: initializeParams.diskEncryptionKey.rsaEncryptedKey
+    diskEncryptionKey.kmsKeyName: initializeParams.diskEncryptionKey.kmsKeySelfLink
+    diskEncryptionKey.sha256: initializeParams.diskEncryptionKey.sha256
+    diskEncryptionKey.kmsKeyServiceAccount: initializeParams.diskEncryptionKey.kmsKeyServiceAccount
+    initializeParams.diskType: disk
+    initializeParams.resourceManagerTags: initializeParams.params.resourceManagerTags
   Exclude:
   - type
   - savedState
   - source # ComputedInstance
   - boot # ComputedInstance
   - initializeParams.licenses
+  - shieldedInstanceInitialState.pk.content
+  - shieldedInstanceInitialState.pk.fileType
+  - shieldedInstanceInitialState.keks.content
+  - shieldedInstanceInitialState.keks.fileType
+  - shieldedInstanceInitialState.dbs.content
+  - shieldedInstanceInitialState.dbs.fileType
+  - shieldedInstanceInitialState.dbxs.content
+  - shieldedInstanceInitialState.dbxs.fileType
+  - initializeParams.replicaZones
 
 Autoscaler:
   Mapping:
@@ -57,6 +83,23 @@ InstanceGroup:
 Reservation:
   ExactMapping:
    shareSettings.projectMap: shareSettings.projectMap.id
+  Exclude:
+  - resourceStatus.specificSkuAllocation.sourceInstanceTemplateId
+  - resourceStatus.specificSkuAllocation.utilizations
+  - resourceStatus.reservationMaintenance.upcomingGroupMaintenance.type
+  - resourceStatus.reservationMaintenance.upcomingGroupMaintenance.canReschedule
+  - resourceStatus.reservationMaintenance.upcomingGroupMaintenance.windowStartTime
+  - resourceStatus.reservationMaintenance.upcomingGroupMaintenance.windowEndTime
+  - resourceStatus.reservationMaintenance.upcomingGroupMaintenance.latestWindowStartTime
+  - resourceStatus.reservationMaintenance.upcomingGroupMaintenance.maintenanceStatus
+  - resourceStatus.reservationMaintenance.upcomingGroupMaintenance.maintenanceOnShutdown
+  - resourceStatus.reservationMaintenance.maintenanceOngoingCount
+  - resourceStatus.reservationMaintenance.maintenancePendingCount
+  - resourceStatus.reservationMaintenance.schedulingType
+  - aggregateReservation.inUseResources.accelerator.acceleratorCount
+  - aggregateReservation.inUseResources.accelerator.acceleratorType
+  - resourceStatus.reservationBlockCount
+  - reservationMode
 
 SecurityPolicy:
   Mapping:
@@ -124,6 +167,12 @@ InstanceTemplate:
     aliasIpRange: aliasIpRanges
     networkIp : networkIP
     kmsKeySelfLink: kmsKeyName
+    natIp: natIP
+    serviceAccount: serviceAccounts
+    guestAccelerator: guestAccelerators
+    acceleratorType: type
+    acceleratorCount: count
+    shieldedInstanceConfig: shieldedVmConfig
   ExactMapping:
     disks.initializeParams.diskName: disk.diskName
     disks.initializeParams.diskType: disk.diskType
@@ -134,8 +183,34 @@ InstanceTemplate:
     disks.initializeParams.resourcePolicies: disk.resourcePolicies
     disks.initializeParams.sourceImage: disk.sourceImage
     disks.initializeParams.sourceSnapshot: disk.sourceSnapshot
+    tags.items: tags
+    tags.fingerprint: tagsFingerprint
+    metadata.fingerprint: metadataFingerprint
+    reservationAffinity.consumeReservationType: reservationAffinity.type
+    reservationAffinity.key: reservationAffinity.specificReservation.key
+    reservationAffinity.values: reservationAffinity.specificReservation.values
+    displayDevice.enableDisplay: enableDisplay
   Exclude:
   - disks.initializeParams.diskSizeGb
+  - sourceInstanceParams.diskConfigs.autoDelete
+  - disks.guestOsFeatures.type
+  - disks.shieldedInstanceInitialState.pk.content
+  - disks.shieldedInstanceInitialState.pk.fileType
+  - disks.shieldedInstanceInitialState.keks.content
+  - disks.shieldedInstanceInitialState.keks.fileType
+  - disks.shieldedInstanceInitialState.dbs.content
+  - disks.shieldedInstanceInitialState.dbs.fileType
+  - disks.shieldedInstanceInitialState.dbxs.content
+  - disks.shieldedInstanceInitialState.dbxs.fileType
+  - metadata.items.key
+  - metadata.items.value
+  - scheduling.locationHint
+  - privateIpv6GoogleAccess
+  - sourceInstance
+  - sourceInstanceParams.diskConfigs.deviceName
+  - sourceInstanceParams.diskConfigs.instantiateFrom
+  - sourceInstanceParams.diskConfigs.autoDelete
+  - sourceInstanceParams.diskConfigs.customImage
 
 Instance:
   Mapping:
@@ -317,6 +392,12 @@ ServiceAttachment:
   Exclude:
   - producerForwardingRule
 
+Router:
+  RelatedResources:
+    RouterPeer: bgpPeers
+    RouterNat: nats
+    RouterInterface: interfaces
+
 Route:
   Exclude:
   - kind
@@ -373,6 +454,10 @@ InstanceGroupManager:
   - currentActions.refreshing
 
 FirewallPolicy:
+  RelatedResources:
+    FirewallPolicyRule: rules
+    PacketMirroringRule: packetMirroringRules
+    FirewallPolicyAssociation: associations
   Exclude:
   - kind
   - rules.kind

--- a/src/diff_config.py
+++ b/src/diff_config.py
@@ -12,7 +12,11 @@ API_URLS = {
     "gke-ent": "https://gkehub.googleapis.com/$discovery/rest?version=v1",
     "gke-backup": (
         "https://gkebackup.googleapis.com/$discovery/rest?version=v1"
-    )
+    ),
+    "acc-content-manager": (
+        "https://accesscontextmanager.googleapis.com/$discovery/"
+        "rest?version=v1"
+    ),
 }
 
 TF_RESOURCES = {
@@ -22,6 +26,7 @@ TF_RESOURCES = {
     "gke-std-beta": "google_container_",
     "gke-ent": "google_gke_hub_",
     "gke-backup": "google_gke_backup_",
+    "acc-content-manager": "google_access_context_manager_",
 }
 
 YAML_CONFIG_PATH = (

--- a/src/diff_tf_parser.py
+++ b/src/diff_tf_parser.py
@@ -276,7 +276,7 @@ class DiffTfParser:
         except KeyError:
             pass
 
-    def get_tf_fields(self):
+    def get_tf_fields(self, prepend=None):
         """
         Extracts Terraform field keys from the component schema and populates
         `tf_field_list`.
@@ -295,7 +295,10 @@ class DiffTfParser:
             return False
 
         self.tf_field_list = []
-        self._get_tf_field('', self.component_tf_schema)
+        if not prepend:
+            self._get_tf_field('', self.component_tf_schema)
+        else:
+            self._get_tf_field(prepend, self.component_tf_schema)
 
         if not self.tf_field_list:
             self.log.error("Failed to get Terraform component fields!")


### PR DESCRIPTION
This patch adds support for releated resources.
Some API fields could be added in resources named differently than API schema. Right now tool supports such caseses and addes RelatedResources field to the tool config.